### PR TITLE
Same string printed twice in writeFile() and decryptIMG4()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -543,8 +543,6 @@ void writeFile(std::string FileName, const uint8_t *Data, size_t Size)
   }
   fo.write((const char *)Data, Size);
   fo.close();
-
-  cout << "[!] File succesfully decrypted and written to: " + FileName + "_decrypted" + "\n";
 }
 
 void decryptIMG4(std::string FileName, std::string DecryptedKeyBag)


### PR DESCRIPTION
Hey, 

while using `decryptIMG`  flag I noticed the same string is printed twice :

```
» ./king decryptIMG iBoot.d10.RELEASE.im4p DDD8C8675B09AB9C5B4439012E509F7EA37445B1190121C1BC316EEE49156F1D466A48BD9ABC9C053F16924BB77E58E3
decryptIMG4
IM4P: ---------
type: ibot
desc: iBoot-4513.260.81
size: 0x0006df80
[...]
[!] File succesfully decrypted and written to: iBoot.d10.RELEASE.im4p_decrypted
[!] File succesfully decrypted and written to: iBoot.d10.RELEASE.im4p_decrypted
```

I removed the one in writeFile() function.